### PR TITLE
[Qubes] Ignore qrexec to self during vm shutdown

### DIFF
--- a/usr/lib/sdwdate-gui/notify-shutdown
+++ b/usr/lib/sdwdate-gui/notify-shutdown
@@ -25,7 +25,7 @@ if [ "$gateway" = "" ]; then
    gateway=sys-whonix
 fi
 
-if [ ! -z "$NAME" ]; then
+if [ ! -z "$NAME" ] && [ "$NAME" != "$gateway" ]; then
     /usr/bin/qrexec-client-vm "$gateway" whonix.NewStatus+$NAME" shutdown"
 fi
 


### PR DESCRIPTION
When a gateway or workstation shuts down, it performs a qrexec call of `whonix.NewStatus+this_qube\ shutdown` to its gateway. Default gateway is sys-whonix, can override in /usr/local/etc/sdwdate-gui.d.

When `this_qube` == `sys-whonix`, it's notifying itself. There is no Qubes RPC policy to handle `sys-whonix` to `sys-whonix`, as the policy right now is:

```
$tag:anon-vm $tag:anon-gateway allow
$tag:anon-vm sys-whonix allow
$anyvm $anyvm deny
```

On Qubes R4.0, this results in a silently ignored qrexec deny, observed in the dom0 journal. The `qrexec-client-vm` invocation returns quickly.

However, on Qubes R4.1 (unreleased at time of issue), the user observes:

1. qrexec deny in the dom0 journal
2. A popup message indicating the qrexec call was denied
3. qrexec-client-vm does not return immediately (if at all? TBD)

This results in a 1.5 minute shutdown delay when stopping sys-whonix as well as visual spam/clutter which appears harmless but is unnecessary.